### PR TITLE
Gcc9

### DIFF
--- a/mdca-common/src/collection-tests.cpp
+++ b/mdca-common/src/collection-tests.cpp
@@ -1,7 +1,13 @@
 #include <mdca/collection.hpp>
+#include <mdca/mdca.hpp>
 #include <fost/file>
 #include <fost/log>
 #include <fost/test>
+
+
+namespace {
+    fostlib::module const c_tests{wfp::c_mdca, "collection-tests"};
+}
 
 
 FSL_TEST_SUITE(collection);
@@ -22,9 +28,9 @@ FSL_TEST_FUNCTION(collection_for_one_db) {
     std::set<fostlib::string> bags;
     std::vector<fostlib::jcursor> paths;
     std::vector<std::function<bool(const fostlib::json &)>> ifs;
-    boost::shared_ptr<fostlib::jsondb> dbp{wfp::database("u1", "c1", "db1")};
+    auto dbp{wfp::database("u1", "c1", "db1")};
     fostlib::json meta{wfp::collection("u1", "c1", bags, paths, ifs)};
-    fostlib::log::debug()("meta", meta);
+    fostlib::log::debug(c_tests)("meta", meta);
     FSL_CHECK(meta.has_key("db1"));
     FSL_CHECK(meta["db1"]["stat"].has_key("modified"));
 #ifdef DEBUG
@@ -39,7 +45,7 @@ FSL_TEST_FUNCTION(collection_filters_non_databases) {
     std::set<fostlib::string> bags;
     std::vector<fostlib::jcursor> paths;
     std::vector<std::function<bool(const fostlib::json &)>> ifs;
-    boost::shared_ptr<fostlib::jsondb> dbp{wfp::database("u1", "c2", "db1")};
+    auto dbp{wfp::database("u1", "c2", "db1")};
     fostlib::utf::save_file(
             fostlib::jsondb::get_db_path(
                     "db/"
@@ -47,15 +53,14 @@ FSL_TEST_FUNCTION(collection_filters_non_databases) {
                     "f40f19/c2/file.txt"),
             "");
     fostlib::json meta{wfp::collection("u1", "c2", bags, paths, ifs)};
-    fostlib::log::debug()("meta", meta);
+    fostlib::log::debug(c_tests)("meta", meta);
     FSL_CHECK(meta.has_key("db1"));
     FSL_CHECK(not meta.has_key("file"));
 }
 
 
 FSL_TEST_FUNCTION(add_new_db) {
-    boost::shared_ptr<fostlib::jsondb> dbp{
-            wfp::database("u1", "one", "db-name")};
+    auto dbp{wfp::database("u1", "one", "db-name")};
     FSL_CHECK(dbp.get());
     FSL_CHECK(dbp->filename());
     FSL_CHECK(fostlib::coerce<fostlib::string>(dbp->filename().value())
@@ -64,13 +69,13 @@ FSL_TEST_FUNCTION(add_new_db) {
 
 
 FSL_TEST_FUNCTION(get_existing_db) {
-    boost::shared_ptr<fostlib::jsondb> dbp{wfp::database("u1", "c1", "db2")};
+    auto dbp{wfp::database("u1", "c1", "db2")};
     FSL_CHECK_EQ(dbp, wfp::database("u1", "c1", "db2"));
 }
 
 
 FSL_TEST_FUNCTION(get_object_from_db) {
-    boost::shared_ptr<fostlib::jsondb> dbp{wfp::database("u1", "c3", "db3")};
+    auto dbp{wfp::database("u1", "c3", "db3")};
     fostlib::jsondb::local db_transaction(*dbp);
     FSL_CHECK_EQ(db_transaction[fostlib::jcursor()], fostlib::json());
 

--- a/mdca-common/src/collection-tests.cpp
+++ b/mdca-common/src/collection-tests.cpp
@@ -75,7 +75,10 @@ FSL_TEST_FUNCTION(get_existing_db) {
 
 
 FSL_TEST_FUNCTION(get_object_from_db) {
-    auto dbp{wfp::database("u1", "c3", "db3")};
+    /// Pick a new test name each run so that if we do run the test
+    /// multiple times it stands a chance of passing
+    auto const dbname = fostlib::guid();
+    auto dbp{wfp::database("u1", "c3", dbname)};
     fostlib::jsondb::local db_transaction(*dbp);
     FSL_CHECK_EQ(db_transaction[fostlib::jcursor()], fostlib::json());
 

--- a/mdca-common/src/collection.cpp
+++ b/mdca-common/src/collection.cpp
@@ -7,7 +7,7 @@
 #include <fost/push_back>
 #include <fost/urlhandler>
 
-#if __has_include(<filesystem>) || __has_include(<experimental/filesystem>)
+#if defined(__ANDROID__) && (__has_include(<filesystem>) || __has_include(<experimental/filesystem>))
 #if __has_include(<filesystem>)
 #include <filesystem>
 namespace fs = std::filesystem;

--- a/mdca-common/src/collection.cpp
+++ b/mdca-common/src/collection.cpp
@@ -56,7 +56,7 @@ namespace {
         } else {
             return boost::filesystem::path("db")
                     / fostlib::coerce<boost::filesystem::path>(
-                              fostlib::sha256(user))
+                            fostlib::sha256(user))
                     / boost::filesystem::path(std::string(collection));
         }
     }

--- a/mdca-common/src/webcapture.cpp
+++ b/mdca-common/src/webcapture.cpp
@@ -52,7 +52,7 @@ namespace {
                         fostlib::crypto_compare(
                                 signature, fostlib::string(check).substr(0, 43))
                         || fostlib::crypto_compare(
-                                   signature, fostlib::string(check));
+                                signature, fostlib::string(check));
 
                 auto jwt = fostlib::jwt::mint(fostlib::jwt::alg::HS256);
                 jwt.subject(key_name);

--- a/mdca-common/src/webcapture.cpp
+++ b/mdca-common/src/webcapture.cpp
@@ -24,7 +24,7 @@ namespace {
                 f5::u8view prefix = "?";
 
                 for (auto query_pair : fostlib::splitter(query, '&')) {
-                    const auto query_start = query_pair.substr(0, 3);
+                    const auto query_start = query_pair.substr_pos(0, 3);
 
                     if (query_start == "_k=") {
                         key_name = req.query_string()["_k"].value();

--- a/mdca-simulator/src/barcode-view-simulator.cpp
+++ b/mdca-simulator/src/barcode-view-simulator.cpp
@@ -1,5 +1,6 @@
 #include <mdca/activity.hpp>
 #include <mdca/collection.hpp>
+#include <mdca/mdca.hpp>
 #include <beanbag/beanbag>
 #include <fost/datetime>
 #include <fost/insert>
@@ -11,6 +12,9 @@ using namespace fostlib;
 
 
 namespace {
+
+
+    fostlib::module const c_barcode{wfp::c_mdca, "barcode"};
 
 
     const struct barcode : public mdca::activity {
@@ -31,7 +35,7 @@ namespace {
                             .set(path / "completed", timestamp::now())
                             .commit();
                 } catch (std::exception &e) {
-                    log::error()("photo-exception", e.what());
+                    log::error(c_barcode)("photo-exception", e.what());
                     absorb_exception();
                 }
                 locked = fostlib::null;


### PR DESCRIPTION
This is to support builds using newer versions of gcc. I thought most of this was already in master, but anyway the main change here is to only use `std::filesystem` on Android for now until the breakage in gcc 9.x gets fixed.

Tested on Linux, Macos, Android and iOS.